### PR TITLE
Handle missing fonts (origwidth=0)

### DIFF
--- a/font-to-width.js
+++ b/font-to-width.js
@@ -205,6 +205,10 @@ FontToWidth.prototype.measureFonts = function() {
         spans.each(function(i) {
             var span = $(this);
             origwidths[i] = span.width();
+            if (origwidths[i] == 0) {
+                //font could not be loaded
+                origwidths[i] = -1;
+            }
             span.css('font-family', span.data('font-family') + ', AdobeBlank');
         });
         setTimeout(measurefunc, 50); //again allow a bit of time for the new fonts to take


### PR DESCRIPTION
It seems like with non-available fonts, e.g. "Helvetica Narrow" not
being installed, `origwidth` is 0 and font-to-width will keep looping
over it until it gives up eventually.

This sets `origwidth` to -1 in this case, so that the `allLoaded =
false` code path is not triggered for / because of it.

I am not sure if that's the correct way to address this..
